### PR TITLE
perception_lm: export PerceptionEncoder alias for auto mapping

### DIFF
--- a/src/transformers/models/perception_lm/modeling_perception_lm.py
+++ b/src/transformers/models/perception_lm/modeling_perception_lm.py
@@ -319,6 +319,11 @@ class PerceptionLMModel(PerceptionLMPreTrainedModel):
         )
 
 
+# Backward-compatibility alias expected by Auto mappings
+# Auto MODEL_MAPPING may expect a base class named `PerceptionEncoder`.
+# Provide a thin alias so lazy auto-mapping can resolve the symbol.
+PerceptionEncoder = PerceptionLMModel
+
 @auto_docstring
 class PerceptionLMForConditionalGeneration(PerceptionLMPreTrainedModel, GenerationMixin):
     _checkpoint_conversion_mapping = {}
@@ -484,4 +489,9 @@ class PerceptionLMForConditionalGeneration(PerceptionLMPreTrainedModel, Generati
         return model_inputs
 
 
-__all__ = ["PerceptionLMForConditionalGeneration", "PerceptionLMPreTrainedModel", "PerceptionLMModel"]
+__all__ = [
+    "PerceptionLMForConditionalGeneration",
+    "PerceptionLMPreTrainedModel",
+    "PerceptionLMModel",
+    "PerceptionEncoder",
+]

--- a/src/transformers/models/perception_lm/modular_perception_lm.py
+++ b/src/transformers/models/perception_lm/modular_perception_lm.py
@@ -434,8 +434,15 @@ class PerceptionLMForConditionalGeneration(LlavaForConditionalGeneration):
         raise AttributeError("Not needed for PerceptionLM")
 
 
+# Backward-compatibility alias expected by Auto mappings.
+# Auto MODEL_MAPPING may expect a base class named `PerceptionEncoder`.
+# Provide a thin alias so lazy auto-mapping can resolve the symbol.
+PerceptionEncoder = PerceptionLMModel
+
+
 __all__ = [
     "PerceptionLMForConditionalGeneration",
     "PerceptionLMPreTrainedModel",
     "PerceptionLMModel",
+    "PerceptionEncoder",
 ]


### PR DESCRIPTION
### What does this PR do?

Exports a minimal alias for PerceptionLM’s base model so Auto mappings resolve correctly.

- Adds `PerceptionEncoder = PerceptionLMModel`
- Exports `PerceptionEncoder` in `perception_lm` (modular source; regenerated modeling mirrors it)
- Unblocks iterating over `MODEL_MAPPING.items()` without changing runtime behavior

Fixes: [#41387](https://github.com/huggingface/transformers/issues/41387)

### Motivation

Auto mapping expected `PerceptionEncoder`, but only `PerceptionLMModel` was exported, causing lookup failures when enumerating mappings.

### Dependencies

None.

### Before submitting

- [x] This PR is a minimal fix (no behavior change).
- [x] I read the contributor guideline PR section.
- [x] Discussed/linked in issue [#41387](https://github.com/huggingface/transformers/issues/41387).
- [x] No docs changes required (symbol export only).
- [x] Tests: local sanity check with `PYTHONPATH=src` and:
```python
from transformers.models.auto.modeling_auto import MODEL_MAPPING
list(MODEL_MAPPING.items())
```
passes.

### Who can review?

- Model loading / auto mappings: @CyrilVallez
- Multimodal models: @zucchini-nlp




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Restores API compatibility by exposing PerceptionEncoder as an alias of PerceptionLMModel, ensuring existing imports and lazy auto-mapping continue to work without changes.
  - No impact on model behavior; this update only affects public naming to prevent integration breakages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->